### PR TITLE
adds a surgical bag to the merchants shop

### DIFF
--- a/code/modules/cargo/packsrogue/merchant/tools.dm
+++ b/code/modules/cargo/packsrogue/merchant/tools.dm
@@ -234,3 +234,8 @@
 	cost = 10
 	contains = list(/obj/item/storage/hip/headhook)
 
+/datum/supply_pack/rogue/tools/surgicalbag
+	name = "Surgical Bag, Full"
+	cost = 80
+	contains = list(/obj/item/storage/belt/rogue/surgery_bag)
+


### PR DESCRIPTION
## About The Pull Request

Adds a filled out surgical bag available for purchase from the merchant.

## Testing Evidence

Screenshot!

## Why It's Good For The Game

Right now, if all of the bags would go missing, people would be unable to procure them again. Insane material cost + the inability to craft the bags themselves.
