### PR TITLE
vizier clothing changes

### DIFF
--- a/code/modules/clothing/rogueclothes/armor.dm
+++ b/code/modules/clothing/rogueclothes/armor.dm
@@ -321,7 +321,16 @@
 	desc = "A thick robe intervowen with spell-laced fabrics. Thick and protective while remaining light and breezy; the perfect gear for protecting one from the threats of the sun, the desert and the daemons, yet still allowing one to cast spells aptly."
 	naledicolor = TRUE
 	shiftable = FALSE
-
+	
+/obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant/grey
+	name = "hierophant's shawl"
+	icon_state = "desertrobe"
+	item_state = "desertrobe"
+	desc = "A thick robe intervowen with spell-laced fabrics. Thick and protective while remaining light and breezy; the perfect gear for protecting one from the threats of the sun, the desert and the daemons, yet still allowing one to cast spells aptly."
+	naledicolor = FALSE
+	shiftable = FALSE
+	color = CLOTHING_GREY
+	
 /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/pontifex
 	name = "pontifex's kaftan"
 	icon_state = "monkleather"

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -154,19 +154,19 @@
 			H.change_stat("intelligence", 3)
 			H.change_stat("speed", 2)
 			r_hand = /obj/item/rogueweapon/woodstaff/naledi
-			armor = /obj/item/clothing/suit/roguetown/shirt/robe/magered
-
-			mask = /obj/item/clothing/mask/rogue/lordmask/tarnished
+			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant
+				color = CLOTHING_GREY
+			mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor
-			pants = /obj/item/clothing/under/roguetown/trou/leather
-			shoes = /obj/item/clothing/shoes/roguetown/boots
-			gloves = /obj/item/clothing/gloves/roguetown/angle
+			pants = /obj/item/clothing/under/roguetown/trou/leather/pontifex
+			shoes = /obj/item/clothing/shoes/roguetown/sandals
+			gloves = /obj/item/clothing/gloves/roguetown/angle/pontifex
 			backr = /obj/item/storage/backpack/rogue/satchel/black
 			head = /obj/item/clothing/head/roguetown/roguehood/shalal/black
 			cloak = /obj/item/clothing/cloak/half
 			H.grant_language(/datum/language/celestial)
-			shirt = /obj/item/clothing/suit/roguetown/armor/gambeson/lord
+			shirt = /obj/item/clothing/suit/roguetown/shirt/robe/hierophant
 
 			backpack_contents = list(/obj/item/roguekey/mercenary,/obj/item/rogueweapon/huntingknife, /obj/item/storage/belt/rogue/surgery_bag)
 			

--- a/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
+++ b/code/modules/jobs/job_types/roguetown/mercenaries/classes/warscholar.dm
@@ -154,8 +154,7 @@
 			H.change_stat("intelligence", 3)
 			H.change_stat("speed", 2)
 			r_hand = /obj/item/rogueweapon/woodstaff/naledi
-			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant
-				color = CLOTHING_GREY
+			armor = /obj/item/clothing/suit/roguetown/armor/gambeson/heavy/hierophant/grey
 			mask = /obj/item/clothing/mask/rogue/lordmask/naledi
 			belt = /obj/item/storage/belt/rogue/leather
 			beltr = /obj/item/storage/belt/rogue/pouch/coins/poor


### PR DESCRIPTION
## About The Pull Request

changes vizier gear to the mix of pontifex/hierophant
yes, it is coal to reuse the assets of other naledi classes, but the other 2 share gear and have unique sprites, whilst vizier gets only a half-mask.
tbh i'd just copy the hierophant's loadout to vizier, but that'd make their looks identical
## Testing Evidence

screenshots!
![Screenshot 2025-07-01 201604](https://github.com/user-attachments/assets/ff373b39-a98b-468b-89d0-7da7a15f776b)
![Screenshot 2025-07-01 201609](https://github.com/user-attachments/assets/ddbd4bd1-be4f-4beb-8757-a1190500265b)
![Screenshot 2025-07-01 201615](https://github.com/user-attachments/assets/6109da06-c07c-468d-a603-9a3aa6bf8a3e)
![Screenshot 2025-07-01 201622](https://github.com/user-attachments/assets/5705d040-7d04-4c92-b5f4-5f99d9fedd53)

compared to:

![Screenshot 2025-07-01 180755](https://github.com/user-attachments/assets/f82d5041-336c-4062-8c3d-3c577c7ffa7c)

## Why It's Good For The Game

drip
/