### PR TITLE
Bugfix: Instrument Song Loop Time Was Pointless

### DIFF
--- a/code/game/objects/items/rogueitems/dmusicbox.dm
+++ b/code/game/objects/items/rogueitems/dmusicbox.dm
@@ -1,10 +1,10 @@
 
 /datum/looping_sound/dmusloop
 	mid_sounds = list()
-	mid_length = 2400
+	mid_length = 12000 // 20 minutes to force a loop. File size determines server load, not audio length. Low bitrate .ogg files can run long and have their uses as ambient sound.
 	volume = 100
 	falloff = 2
-	extra_range = 5
+	extra_range = 10	// Up from 5, fill a room.
 	var/stress2give = /datum/stressevent/music
 	persistent_loop = TRUE
 	channel = CHANNEL_CMUSIC

--- a/code/game/objects/items/rogueitems/instruments.dm
+++ b/code/game/objects/items/rogueitems/instruments.dm
@@ -1,7 +1,7 @@
 /datum/looping_sound/instrument
-	mid_length = 2400 // 4 minutes for some reason. better would be each song having a specific length
+	mid_length = 120000 // 20 minutes. Previously 4 minutes for no reason. Songs are restricted to 6 megs. If you have twenty minutes of mono low bitrate or one minute of studio quality orchestra, it makes no difference to the server.
 	volume = 100
-	extra_range = 5
+	extra_range = 10	// Increase sound range.
 	persistent_loop = TRUE
 	var/stress2give = /datum/stressevent/music
 	sound_group = /datum/sound_group/instruments //reserves sound channels for up to 10 instruments at a time

--- a/code/modules/roguetown/roguecrafting/sewing.dm
+++ b/code/modules/roguetown/roguecrafting/sewing.dm
@@ -1124,7 +1124,7 @@ datum/crafting_recipe/roguetown/sewing/Purdress
 				/obj/item/natural/fibers = 4)
 	craftdiff = 2
 
-surgical-bag-merchants
+//surgical-bag-merchants
 /datum/crafting_recipe/roguetown/sewing/surgicalbag
 	name = "surgeon's bag (3 fibers, 1 cloth)"
 	result = list(/obj/item/storage/belt/rogue/surgery_bag/empty)


### PR DESCRIPTION
## About The Pull Request

Solves a bug/false feature in instrument code.

Allows audio files to play out rather than force them to loop after four minutes.
Audio files are still limited to 6 megabytes, this was the case before the PR as well.
Before the PR, long musical pieces could be uploaded under 6 megs but could not play out due to the arbitrary forced loop.
This removes that arbitrary loop (shifting it to 20 minutes to handle whatever edge case) and has it loop naturally at the end of the song.
Players with a particularly long but well-compressed or simple .ogg file have the same impact on the server as a short but uncompressed, studio-quality .ogg of only a minute or two playtime; the forced loop was arbitrary and needless.

Some songs in the instruments couldn't even play to their full length previously.

## Testing Evidence

Compiled and tested locally in VSC.
Song under 6 megs but over 4 minutes now loops at the end of the song.

## Why It's Good For The Game

Previously songs looped at four minutes, arbitrarily.
File upload was limited to 6 megs, but 

Increased mid_length, which determines when the sound automatically loops. It is not needed; music loops at the end of the file. Left in place for edge case purposes.
Sound range increased from 5 to 10, letting music be heard at further distances.
This may require tweaking down after play and feedback, but having to stand right next to people to play audible music was bad for musicians acting in good faith.